### PR TITLE
Simple table iterator

### DIFF
--- a/ecs.odin
+++ b/ecs.odin
@@ -82,9 +82,11 @@ package ode_ecs
     //
     // Iterator
     //
-        iterator_init       :: iterator__init
-        iterator_next       :: iterator__next   
-        iterator_reset      :: iterator__reset
+        iterator_init       :: proc {iterator__init, table_iterator__init}
+        iterator_next       :: proc { iterator__next, table_iterator__next   }
+        iterator_reset      :: proc{ iterator__reset, table_iterator__reset}
+
+        table_iterator_get :: table_iterator__get
 
     //
     // Outdated aliases (will be removed in future)

--- a/iterator.odin
+++ b/iterator.odin
@@ -112,14 +112,14 @@ import "core:log"
         return self.view_row.raw.eid
     }
 
+
 // TableIterators
 
 TableIterator :: struct($T: typeid) {
 	table:     ^Table(T),
-
 	// current state
 	index:     int,
-	max_index: int,
+	row_count: int,
 }
 
 // Use start_row and end_row if you want to process View in batches
@@ -127,9 +127,9 @@ table_iterator__init :: proc(table: ^Table($T)) -> (iterator: TableIterator(T)) 
 	when VALIDATIONS {assert(table != nil)}
 
 	iterator = TableIterator(T) {
-		table     = table,
+		table = table,
 	}
-    table_iterator__reset(&iterator)
+	table_iterator__reset(&iterator)
 
 	return iterator
 }
@@ -137,19 +137,30 @@ table_iterator__init :: proc(table: ^Table($T)) -> (iterator: TableIterator(T)) 
 table_iterator__reset :: proc(iterator: ^TableIterator($T)) {
 	when VALIDATIONS {assert(iterator.table != nil)}
 	iterator.index = -1
-	iterator.max_index = len(iterator.table.rows)
+	iterator.row_count = len(iterator.table.rows) // actual table capacity, the real bound
 }
 
 table_iterator__next :: proc(iterator: ^TableIterator($T)) -> bool {
-	iterator.index += 1
-	return iterator.index < iterator.max_index
+	for {
+		iterator.index += 1
+		if iterator.index >= iterator.row_count {
+			return false
+		}
+		e := get_entity(iterator.table, iterator.index)
+		if is_entity_expired(iterator.table.db, e) {
+			continue
+		}
+		return true
+	}
 }
 
 
-table_iterator__get :: proc(self: ^TableIterator($T)) -> (
-    component: ^T,
+table_iterator__get :: proc(
+	self: ^TableIterator($T),
+) -> (
+	component: ^T,
 	entity: entity_id,
-    index: int,
+	index: int,
 ) {
 
 	component = &self.table.rows[self.index]

--- a/iterator.odin
+++ b/iterator.odin
@@ -3,6 +3,7 @@
 */
 package ode_ecs
 
+import "core:log"
 // Base
     import "base:runtime"
 // Core
@@ -110,3 +111,49 @@ package ode_ecs
     iterator__get_entity :: #force_inline proc "contextless" (self: ^Iterator) -> entity_id {
         return self.view_row.raw.eid
     }
+
+// TableIterators
+
+TableIterator :: struct($T: typeid) {
+	table:     ^Table(T),
+
+	// current state
+	index:     int,
+	max_index: int,
+}
+
+// Use start_row and end_row if you want to process View in batches
+table_iterator__init :: proc(table: ^Table($T)) -> (iterator: TableIterator(T)) {
+	when VALIDATIONS {assert(table != nil)}
+
+	iterator = TableIterator(T) {
+		table     = table,
+	}
+    table_iterator__reset(&iterator)
+
+	return iterator
+}
+
+table_iterator__reset :: proc(iterator: ^TableIterator($T)) {
+	when VALIDATIONS {assert(iterator.table != nil)}
+	iterator.index = -1
+	iterator.max_index = len(iterator.table.rows)
+}
+
+table_iterator__next :: proc(iterator: ^TableIterator($T)) -> bool {
+	iterator.index += 1
+	return iterator.index < iterator.max_index
+}
+
+
+table_iterator__get :: proc(self: ^TableIterator($T)) -> (
+    component: ^T,
+	entity: entity_id,
+    index: int,
+) {
+
+	component = &self.table.rows[self.index]
+	index = self.index
+	entity = get_entity(self.table, index)
+	return
+}

--- a/iterator.odin
+++ b/iterator.odin
@@ -115,11 +115,17 @@ import "core:log"
 
 // TableIterators
 
+// NOTE:
+// Tables report length as "alive things in this db".
+// Dbs are the underlying structure holding "alive and expired"
+// So the index has no meaning outside of this iterator and/or table,
+// returning it on "get" would be confusing ?
 TableIterator :: struct($T: typeid) {
-	table:     ^Table(T),
+	table:           ^Table(T),
+
 	// current state
-	index:     int,
-	row_count: int,
+	alive_index:           int,
+	alive_index_max: int,
 }
 
 // Use start_row and end_row if you want to process View in batches
@@ -136,35 +142,18 @@ table_iterator__init :: proc(table: ^Table($T)) -> (iterator: TableIterator(T)) 
 
 table_iterator__reset :: proc(iterator: ^TableIterator($T)) {
 	when VALIDATIONS {assert(iterator.table != nil)}
-	iterator.index = -1
-	iterator.row_count = len(iterator.table.rows) // actual table capacity, the real bound
+	iterator.alive_index = -1
+	iterator.alive_index_max = len(iterator.table.rows) // alive things inside this table
 }
 
 table_iterator__next :: proc(iterator: ^TableIterator($T)) -> bool {
-	for {
-		iterator.index += 1
-		if iterator.index >= iterator.row_count {
-			return false
-		}
-		e := get_entity(iterator.table, iterator.index)
-		if is_entity_expired(iterator.table.db, e) {
-			continue
-		}
-		return true
-	}
+	iterator.alive_index += 1
+	return iterator.alive_index < iterator.alive_index_max
 }
 
 
-table_iterator__get :: proc(
-	self: ^TableIterator($T),
-) -> (
-	component: ^T,
-	entity: entity_id,
-	index: int,
-) {
-
-	component = &self.table.rows[self.index]
-	index = self.index
-	entity = get_entity(self.table, index)
+table_iterator__get :: proc(self: ^TableIterator($T)) -> (component: ^T, entity: entity_id) {
+	component = &self.table.rows[self.alive_index]
+	entity = get_entity(self.table, self.alive_index)
 	return
 }


### PR DESCRIPTION
Hi.

---
Current use case.

I noticed I do this a lot:
```odin
		 for &health_c, index in GAME.health.rows {                   // <- relevant
		 	if health_c.current_health < 0.0 {
		 		e := ecs.get_entity(&GAME.health, index)           // <- relevant
		 		ecs_must(ecs.tag(&GAME.ecs_to_be_deleted, e))
		 	}
		 }
```
So I am iterating over the table, but I am always getting the entity. 
For my use case there are no cases in which I don't need the entity. Typically I want to "get the entity that component belongs to, and then get component X,Y,Z which may or may not also belong to that entity."

This means I am virtually always going to call `get_entity`. 
But there is no internal check for `get_entity` that the index you are getting is from the correct table. So I kept accidentally doing this:
```odin
		 for &health_c, index in GAME.health.rows {
		 	if health_c.current_health < 0.0 {
		 		e := ecs.get_entity(&GAME.lifetime, index)            // <- wrong table and index pair
		 		ecs_must(ecs.tag(&GAME.ecs_to_be_deleted, e))
		 	}
		 }
```

This goes through on compile time, and will eventually crash, but debugging it without double checking the correct tables is really confusing as usually the idxn miss-align and I kept searching at the wrong end.

---
The PR

This PR adds a very very simple table iterator that is somewhat modeled after the existing iterators for views, but those are so much more complex that this new one is really just a counter. With this PR the above code turns into:
```odin
		for t_it := ecs.iterator_init(&GAME.health); ecs.iterator_next(&t_it); {
			c, e, i := ecs.table_iterator__get(&t_it)
			if c.current_health < 0.0 {
				ecs_must(ecs.tag(&GAME.ecs_to_be_deleted, e))
			}
		}

```
Which means i can no longer mess this up :)
You can also declare the iterator outside and use reset on it.

I am unhappy with introducing a new function `table_iterator_get` for just this kind of iterator.

To be clear: the problem I have is not at all with ecs functionality. I repeat the same mistake and decided to maybe add some ergonomics to the tables.

The getter returns the component, entity, and index. Which I think is sensible in order of usefulness.